### PR TITLE
Sort word with type

### DIFF
--- a/app/controllers/prohibitions_controller.rb
+++ b/app/controllers/prohibitions_controller.rb
@@ -4,7 +4,7 @@ class ProhibitionsController < ApplicationController
   before_action :set_prohibition, only: %i(update destroy)
 
   def index
-    @prohibitions = @user.prohibitions
+    @prohibitions = @user.prohibitions.sort_by(&:prohibition_type)
   end
 
   def create

--- a/spec/feature/prohibition_spec.rb
+++ b/spec/feature/prohibition_spec.rb
@@ -38,4 +38,15 @@ RSpec.feature 'Prohibition index', type: :feature do
     expect(Prohibition.first.word).to eq('test_word')
     expect(Prohibition.first.prohibition_type).to eq('title')
   end
+
+  context 'there are some prohibitions' do
+    let!(:prohibition1) { create(:title_prohibition, user:user, word:'title_prohibition_example') }
+    let!(:prohibition2) { create(:domain_prohibition, user:user, word:'domain_prohibition_example') }
+
+    scenario 'type order' do
+      visit prohibitions_path
+
+      expect(page.body.index(prohibition2.word)).to be < page.body.index(prohibition1.word)
+    end
+  end
 end


### PR DESCRIPTION
禁止ワードが種類に関係なく並んでいたので、それを修正

closes #47 
